### PR TITLE
Ruby: Change Bundler version to 1.17.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,4 +442,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.1.4
+   1.17.0


### PR DESCRIPTION
It's what we use in production.