### PR TITLE
Reintroduce the bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+bundle config set --local deployment 'true'
+bundle config set --local without 'development test'
+bundle install
+bundle exec rails db:prepare
+bundle exec rails assets:precompile
+
+touch tmp/restart.txt


### PR DESCRIPTION
Rails 7 requires Ruby 2.7 which in turn require Debian 11.  This has to
be taken into account for our deployments on Debian.
