### PR TITLE
Allow overriding CSR subjects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,4 @@ end
 # FIXME: Workaround for Ruby 2.7
 # https://github.com/rails/rails/pull/44175#issuecomment-1023595691
 gem "net-http"
+gem "uri", "0.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    msgpack (1.5.0)
+    msgpack (1.5.1)
     multi_test (0.1.2)
     net-http (0.2.0)
       net-protocol
@@ -231,14 +231,14 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
-    parser (3.1.1.0)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.3.5)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -279,7 +279,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.2.1)
+    regexp_parser (2.3.0)
     reline (0.3.1)
       io-console (~> 0.5)
     responders (3.0.1)
@@ -303,7 +303,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
-    rubocop (1.26.1)
+    rubocop (1.27.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -312,9 +312,9 @@ GEM
       rubocop-ast (>= 1.16.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
-    rubocop-minitest (0.19.0)
+    rubocop-minitest (0.19.1)
       rubocop (>= 0.90, < 2.0)
     rubocop-packaging (0.5.1)
       rubocop (>= 0.89, < 2.0)
@@ -336,7 +336,7 @@ GEM
     rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    ruby_parser (3.19.0)
+    ruby_parser (3.19.1)
       sexp_processor (~> 4.16)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -351,7 +351,7 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sexp_processor (4.16.0)
+    sexp_processor (4.16.1)
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -446,6 +446,7 @@ DEPENDENCIES
   timecop
   turbo-rails
   tzinfo-data
+  uri (= 0.10.0)
   web-console
   webdrivers
 

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -33,7 +33,7 @@ class CertificatesController < ApplicationController
   def create
     case params[:certificate][:method]
     when "csr"
-      @certificate = @certificate_authority.sign_certificate_request(params[:certificate][:csr])
+      @certificate = @certificate_authority.sign_certificate_request(params[:certificate][:csr], subject_override: params[:certificate][:subject])
     when "spkac"
       if params[:public_key].nil?
         @certificate.errors.add(:public_key, :not_set)

--- a/app/models/certificate_authority.rb
+++ b/app/models/certificate_authority.rb
@@ -83,13 +83,17 @@ class CertificateAuthority < Certificate
     end
   end
 
-  def sign_certificate_request(req, export_name = nil)
+  def sign_certificate_request(req, subject_override: nil, export_name: nil)
     req = OpenSSL::X509::Request.new(req)
 
     cert = OpenSSL::X509::Certificate.new
     cert.version = 2
     cert.serial = self.next_serial!
-    cert.subject = req.subject
+    if subject_override.blank?
+      cert.subject = req.subject
+    else
+      cert.subject = OpenSSL::X509::Name.parse(subject_override)
+    end
     cert.issuer = self.certificate.subject
     cert.public_key = req.public_key
     cert.not_before = Time.now

--- a/app/views/certificates/_form.html.haml
+++ b/app/views/certificates/_form.html.haml
@@ -27,6 +27,7 @@
 
       = f.hidden_field :method, value: :csr
       = f.input :csr, as: :text, input_html: { class: "textarea" }
+      = f.input :subject
       = f.submit t(".save"), class: "button is-primary"
       = link_to t(".back"), @certificate.persisted? ? [@certificate_authority, @certificate] : certificate_authority_certificates_path(@certificate_authority), class: "button"
 -#

--- a/features/certificates.feature
+++ b/features/certificates.feature
@@ -1,6 +1,51 @@
 # language: fr
 
 Fonctionnalité: Certificats
+  Scénario: Création d'un certificat avec un CSR
+    Étant donné un administrateur
+    Et une autorité de certification "/C=FR/O=Pakotoa"
+    Lorsqu'il créé un certificat avec ce CSR:
+      """
+      -----BEGIN CERTIFICATE REQUEST-----
+      MIICWzCCAUMCAQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3
+      DQEBAQUAA4IBDwAwggEKAoIBAQDj2Wr3CUPQ8sRC2HAlkuPs1C9DJPaQepkw6nJZ
+      6h9J9ms5ABqcHsLZemVXjIY6Lpi0CJ/Thp7Mw31xpbhIF9SFJmjF3IC4VQ9etKOz
+      HZ24Z88rAqny2DjwKxHT+0qBr90jOlE3BXJSN+jqybRKY4LUd7YQ2KD1qz0MQHth
+      /ZcnSEkxf3YnxVyBO9DmAG6Tl0nvFTnlT/QTZENN4rhcmGIj5Fbqu4/4O3ObQ3vY
+      p0DJl4AvHLMxi6JZ7wTynWi6OEjUNSICEgOMBMaACwfcFcBygKFWhcB8D6SMHGYR
+      CuQHdrvE69y/6sw/fRURwaQgaJD5CCm5IEISIJWdqfyvU2j1AgMBAAGgADANBgkq
+      hkiG9w0BAQsFAAOCAQEAlzBFpDvIaBvItvlrkkfET4wlD3MAFQ+e9w9BaFD0ExLA
+      mrcOTxtGwoMAJnWJZvI+/Qyd1laZnvSa03OHN/IC143S0ty/OuEGWAKJ6EdpbHEm
+      rQ98e7FQ/VL7Kw43i3HgqjPy6V+q/+soW+hcMx2dS2aR6UwDspuwIUJ3SOvmnL2Y
+      6P9NzECEGOFrfaNQKNtqxapuQffi/Pn5/OYvtj79U5pPeB9g6RBd70pTFH7hROb4
+      FjgNB9dnXISS0lmRv7gly+TsvP9UNflUd2WzzmfABSVkexoY2tpBeE3HwtE5FPYJ
+      SJD1kM4LQEQs9PasgSSaZI4PPoP5+1gexmTgrkDXtw==
+      -----END CERTIFICATE REQUEST-----
+      """
+  Alors il voit un certificat avec pour sujet "/CN=example.com"
+
+  Scénario: Réécriture du sujet d'un certificat
+    Étant donné un administrateur
+    Et une autorité de certification "/C=FR/O=Pakotoa"
+    Lorsqu'il créé un certificat avec ce CSR et le sujet "/CN=overriden.example.com":
+      """
+      -----BEGIN CERTIFICATE REQUEST-----
+      MIICWzCCAUMCAQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3
+      DQEBAQUAA4IBDwAwggEKAoIBAQDj2Wr3CUPQ8sRC2HAlkuPs1C9DJPaQepkw6nJZ
+      6h9J9ms5ABqcHsLZemVXjIY6Lpi0CJ/Thp7Mw31xpbhIF9SFJmjF3IC4VQ9etKOz
+      HZ24Z88rAqny2DjwKxHT+0qBr90jOlE3BXJSN+jqybRKY4LUd7YQ2KD1qz0MQHth
+      /ZcnSEkxf3YnxVyBO9DmAG6Tl0nvFTnlT/QTZENN4rhcmGIj5Fbqu4/4O3ObQ3vY
+      p0DJl4AvHLMxi6JZ7wTynWi6OEjUNSICEgOMBMaACwfcFcBygKFWhcB8D6SMHGYR
+      CuQHdrvE69y/6sw/fRURwaQgaJD5CCm5IEISIJWdqfyvU2j1AgMBAAGgADANBgkq
+      hkiG9w0BAQsFAAOCAQEAlzBFpDvIaBvItvlrkkfET4wlD3MAFQ+e9w9BaFD0ExLA
+      mrcOTxtGwoMAJnWJZvI+/Qyd1laZnvSa03OHN/IC143S0ty/OuEGWAKJ6EdpbHEm
+      rQ98e7FQ/VL7Kw43i3HgqjPy6V+q/+soW+hcMx2dS2aR6UwDspuwIUJ3SOvmnL2Y
+      6P9NzECEGOFrfaNQKNtqxapuQffi/Pn5/OYvtj79U5pPeB9g6RBd70pTFH7hROb4
+      FjgNB9dnXISS0lmRv7gly+TsvP9UNflUd2WzzmfABSVkexoY2tpBeE3HwtE5FPYJ
+      SJD1kM4LQEQs9PasgSSaZI4PPoP5+1gexmTgrkDXtw==
+      -----END CERTIFICATE REQUEST-----
+      """
+  Alors il voit un certificat avec pour sujet "/CN=overriden.example.com"
 
   Scénario: Révocation de certificats
     Étant donné un administrateur

--- a/features/step_definitions/certificate_authority_steps.rb
+++ b/features/step_definitions/certificate_authority_steps.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Étantdonné(/^une autorité de certification "([^"]*)"$/) do |subject|
-  User.last.certificate_authorities << create(:certificate_authority, subject: subject)
+  click_on "Certificate Authorities"
+  click_on "New Certificate Authority"
+  fill_in "Subject", with: subject
+  click_on "Save"
 end
 
 Lorsqu(/^il créé une autorité de certification "([^"]*)"$/) do |subject|

--- a/features/step_definitions/certificate_steps.rb
+++ b/features/step_definitions/certificate_steps.rb
@@ -7,3 +7,22 @@ end
 Étantdonné(/^le certificat "([^"]*)" est révoqué$/) do |subject|
   Certificate.find_by(subject: subject).update(revoked_at: Time.now)
 end
+
+Lorsqu("il créé un certificat avec ce CSR:") do |csr|
+  click_on "Manage Certificates"
+  click_on "Create Certificate"
+  fill_in "Certificate Signing Request", with: csr
+  click_on "Save"
+end
+
+Lorsqu("il créé un certificat avec ce CSR et le sujet {string}:") do |subject, csr|
+  click_on "Manage Certificates"
+  click_on "Create Certificate"
+  fill_in "Certificate Signing Request", with: csr
+  fill_in "Subject", with: subject
+  click_on "Save"
+end
+
+Alors("il voit un certificat avec pour sujet {string}") do |subjet|
+  expect(page).to have_content(subjet)
+end


### PR DESCRIPTION
When a CSR is submitted, also provide a Subject field to override the
user supplied subject which is stored in the CSR.

This makes it easier to manage certificates that match policies for non
tech-savvy users.

This PR also include:
* #28 