### PR TITLE
Tune dependabot to not touch Gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: daily
       time: "13:00"
     open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
   
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
Only udpate Gemfile.lock when a new version is available, but do not
touch the Gemfile.  That way, the Gemfile basically list minimum
requirements and is only updated when these requirements change.
