### PR TITLE
Do not abbreviate certificates subjects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
   end
 
   def certificate_authority_title
-    helpers.abbr_subject(@certificate_authority.subject)
+    @certificate_authority.subject
   end
 
   def policy_title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,14 +7,6 @@ module ApplicationHelper
     link_to text, url, options.merge(class: classes.join(" "))
   end
 
-  def abbr_subject(subject)
-    if subject =~ /CN=(.*)\// then
-      $1
-    else
-      subject
-    end
-  end
-
   def certificate_icon(certificate, options = {})
     if certificate.revoked_at.nil? && certificate.not_after.future? then
       fa_icon("certificate", options)

--- a/app/views/certificate_authorities/edit.html.haml
+++ b/app/views/certificate_authorities/edit.html.haml
@@ -1,4 +1,4 @@
-= content_for(:title, abbr_subject(@certificate_authority.subject))
+= content_for(:title, @certificate_authority.subject)
 
 = simple_form_for @certificate_authority do |f|
   = f.input :current_password

--- a/app/views/certificate_authorities/show.html.haml
+++ b/app/views/certificate_authorities/show.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title) { abbr_subject(@certificate_authority.subject) }
+- content_for(:title) { @certificate_authority.subject }
 
 - if false
   .notification.is-warning

--- a/app/views/certificates/show.html.haml
+++ b/app/views/certificates/show.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title) { abbr_subject(@certificate.subject) }
+- content_for(:title) { @certificate.subject }
 
 .columns
   .column.is-two-thirds

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -39,8 +39,8 @@
             %ul
               - if @breadcrumb
                 - @breadcrumb.each do |part|
-                  %li= link_to abbr_subject(part[0]), part[1]
-              %li.is-active= link_to abbr_subject(content_for(:title)), "#"
+                  %li= link_to part[0], part[1]
+              %li.is-active= link_to content_for(:title), "#"
         - if flash[:notice]
           .notification.is-success= flash[:notice]
         - if flash[:alert]


### PR DESCRIPTION
The matching regexp is wrong, but while fixing it we realized it was not a good idea to try to hide some parts of the subject for the sake of legibility: some subject naming may end-up with different certificates being abbreviated the same way, making it harder to distinguish two distinct certificates.


Also include:
* #199
* #200
