### PR TITLE
Remove legacy dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,8 +98,3 @@ group :test do
   gem "timecop"
   gem "webdrivers"
 end
-
-# FIXME: Workaround for Ruby 2.7
-# https://github.com/rails/rails/pull/44175#issuecomment-1023595691
-gem "net-http"
-gem "uri", "0.10.0"

--- a/Gemfile
+++ b/Gemfile
@@ -96,5 +96,4 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov"
   gem "timecop"
-  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,6 @@ GEM
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
     ffi (1.17.0)
-    ffi (1.17.0-x86_64-linux-gnu)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
     globalid (1.2.1)
@@ -190,7 +189,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.7.2)
-    irb (1.14.0)
+    irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.13.0)
@@ -216,13 +215,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
     minitest (5.25.1)
     msgpack (1.7.2)
     multi_test (1.1.0)
     mutex_m (0.2.0)
-    net-http (0.4.1)
-      uri
     net-imap (0.4.16)
       date
       net-protocol
@@ -233,9 +229,6 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.7)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -303,7 +296,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -388,8 +381,6 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3)
-      mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-x86_64-linux)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
@@ -408,7 +399,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
-    uri (0.10.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -420,7 +410,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0, < 4.11)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -430,8 +420,6 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
-  amd64-freebsd-13
-  amd64-freebsd-14
   x86_64-linux
 
 DEPENDENCIES
@@ -452,7 +440,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   listen (~> 3.3)
-  net-http
   pg (~> 1.5)
   puma (~> 6.2)
   rails (~> 7.1.0)
@@ -473,7 +460,6 @@ DEPENDENCIES
   timecop
   turbo-rails
   tzinfo-data
-  uri (= 0.10.0)
   web-console
   webdrivers
 
@@ -481,4 +467,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.5.14
+   2.3.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.25.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -406,10 +408,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webrick (1.8.2)
     websocket (1.2.11)
     websocket-driver (0.7.6)
@@ -461,7 +459,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.1.2p20


### PR DESCRIPTION
The webdrivers gem is now deprecated since selenium itself now manages drivers by default:
https://www.selenium.dev/documentation/selenium_manager
    
Remove it to make it possible to update selenium.

Also include:
* #212
