### PR TITLE
Fix the ruby major.minor version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby ">= 3.1.2"
+ruby "~> 3.1.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.0"


### PR DESCRIPTION
Dependabots wants to bring in dependencies that are not compatible with our requirements as expressed in `.ruby-version`.  Maybe setting more strict requirements in the Gemfile will help.